### PR TITLE
[feature] (#9) Auth: Redis-based Refresh Token Rotation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,11 @@ DB_NAME=sangcheol
 
 REDIS_URL=redis://localhost:6379/0
 
-JWT_SECRET=change-me
+JWT_SECRET=use-a-long-random-string
 JWT_EXPIRES_SEC=3600
+
+REFRESH_EXPIRES_SEC=2592000
+REFRESH_HASH_PEPPER=use-a-long-random-string
 
 GOOGLE_CLIENT_IDS=your-google-client-id1,your-google-client-id2,...
 GOOGLE_CLIENT_SECRET=your-google-client-secret

--- a/app/api/v1/endpoints/__init__.py
+++ b/app/api/v1/endpoints/__init__.py
@@ -1,9 +1,12 @@
 from fastapi import APIRouter
-from app.schemas.base_response import BaseResponse
-from app.api.v1.endpoints import ping, auth_google, users, identities
+from app.api.v1.endpoints import (
+    ping, auth_google, users, identities,
+    auth_tokens
+)
 
 api_router = APIRouter()
 api_router.include_router(ping.router)
 api_router.include_router(auth_google.router)
 api_router.include_router(users.router)
 api_router.include_router(identities.router)
+api_router.include_router(auth_tokens.router)

--- a/app/api/v1/endpoints/auth_tokens.py
+++ b/app/api/v1/endpoints/auth_tokens.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+from pydantic import BaseModel
+
+from app.core.session import get_session
+from app.deps.auth import get_current_user_id
+from app.services.auth_service import rotate_refresh_and_issue, logout_all_refresh
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+class RefreshBody(BaseModel):
+    refresh_token: str
+
+@router.post("/refresh")
+async def refresh(body: RefreshBody, db: AsyncSession = Depends(get_session)):
+    return await rotate_refresh_and_issue(db, body.refresh_token)
+
+@router.post("/logout")
+async def logout(user_id: str = Depends(get_current_user_id)):
+    return await logout_all_refresh(user_id)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -17,8 +17,12 @@ class Settings(BaseSettings):
 
     REDIS_URL: str = "redis://localhost:6379/0"
 
-    JWT_SECRET: str = "change-me"
+    JWT_SECRET: str = ""
     JWT_EXPIRES_SEC: int = 3600
+    REFRESH_EXPIRES_SEC: int = 30 * 24 * 3600
+    REFRESH_REDIS_PREFIX: str = "rtk:"
+    REFRESH_USER_SET_PREFIX: str = "rtu:"
+    REFRESH_HASH_PEPPER: str | None = None
 
     GOOGLE_CLIENT_IDS: str = ""
     GOOGLE_CLIENT_SECRET: str | None = None # 웹 클라에만 필요

--- a/app/utils/redis_client.py
+++ b/app/utils/redis_client.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+from redis.asyncio import from_url, Redis
+from app.core.config import settings
+
+_redis: Redis | None = None
+
+def get_redis() -> Redis:
+    global _redis
+    if _redis is None:
+        _redis = from_url(
+            settings.REDIS_URL,
+            encoding="utf-8",
+            decode_responses=True,
+        )
+    return _redis

--- a/app/utils/refresh_tools.py
+++ b/app/utils/refresh_tools.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+import secrets, hmac, hashlib, json
+from datetime import datetime, timezone
+from typing import TypedDict
+from app.core.config import settings
+
+class RefreshRecord(TypedDict):
+    user_id: str
+    iat: int
+    exp: int
+
+def now_ts() -> int:
+    return int(datetime.now(timezone.utc).timestamp())
+
+def exp_ts() -> int:
+    return now_ts() + int(settings.REFRESH_EXPIRES_SEC)
+
+def _pepper() -> bytes:
+    return (settings.REFRESH_HASH_PEPPER or settings.JWT_SECRET).encode("utf-8")
+
+def generate_refresh_plain() -> str:
+    return secrets.token_urlsafe(64)
+
+def hash_refresh(plain: str) -> str:
+    return hmac.new(_pepper(), plain.encode("utf-8"), hashlib.sha256).hexdigest()
+
+def _env_prefix() -> str:
+    raw = (getattr(settings, "APP_ENV", "") or "").strip().lower()
+    mapping = {
+        "dev": "dev", "development": "dev",
+        "stg": "stg", "stage": "stg", "staging": "stg",
+        "prod": "prod", "production": "prod",
+    }
+    env = mapping.get(raw, "dev")
+    return env + ":"
+
+def redis_token_key(token_hash: str) -> str:
+    return f"{_env_prefix()}{settings.REFRESH_REDIS_PREFIX}{token_hash}"
+
+def redis_user_set_key(user_id: str) -> str:
+    return f"{_env_prefix()}{settings.REFRESH_USER_SET_PREFIX}{user_id}"
+
+def to_json(record: RefreshRecord) -> str:
+    return json.dumps(record)
+
+def from_json(s: str) -> RefreshRecord:
+    return json.loads(s)

--- a/tests/api/test_auth_google.py
+++ b/tests/api/test_auth_google.py
@@ -1,0 +1,53 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from app.main import app
+from app.core.session import get_session
+from app.api.v1.endpoints import auth_google
+
+@pytest.mark.asyncio
+async def test_google_exchange(monkeypatch, client):
+    async def override_session():
+        yield AsyncMock()
+    app.dependency_overrides[get_session] = override_session
+
+    monkeypatch.setattr(auth_google.settings, "GOOGLE_CLIENT_ID_WEB", "cid")
+    monkeypatch.setattr(auth_google.settings, "GOOGLE_REDIRECT_URI", "redir")
+
+    async def fake_exchange(req):
+        return SimpleNamespace(id_token="id")
+
+    async def fake_verify(token):
+        return {"sub": "s"}
+
+    async def fake_handle(db, claims):
+        return {"access_token": "a", "expires_in": 3600, "is_new_user": False, "token_type": "bearer"}
+
+    monkeypatch.setattr(auth_google, "exchange_google_token", fake_exchange)
+    monkeypatch.setattr(auth_google, "verify_google_id_token", fake_verify)
+    monkeypatch.setattr(auth_google, "handle_google_login", fake_handle)
+
+    resp = await client.post("/v1/auth/google/exchange", json={"code": "c", "code_verifier": "v"})
+    assert resp.status_code == 200
+    assert resp.json()["access_token"] == "a"
+    app.dependency_overrides.clear()
+
+@pytest.mark.asyncio
+async def test_google_verify_id_token(monkeypatch, client):
+    async def override_session():
+        yield AsyncMock()
+    app.dependency_overrides[get_session] = override_session
+
+    async def fake_verify(token):
+        return {"sub": "s"}
+
+    async def fake_handle(db, claims):
+        return {"access_token": "a", "expires_in": 3600, "is_new_user": False, "token_type": "bearer"}
+
+    monkeypatch.setattr(auth_google, "verify_google_id_token", fake_verify)
+    monkeypatch.setattr(auth_google, "handle_google_login", fake_handle)
+
+    resp = await client.post("/v1/auth/google/verify-id-token", json={"id_token": "t"})
+    assert resp.status_code == 200
+    assert resp.json()["access_token"] == "a"
+    app.dependency_overrides.clear()

--- a/tests/api/test_auth_tokens.py
+++ b/tests/api/test_auth_tokens.py
@@ -1,0 +1,34 @@
+import pytest
+from unittest.mock import AsyncMock
+from app.main import app
+from app.core.session import get_session
+from app.deps.auth import get_current_user_id
+from app.api.v1.endpoints import auth_tokens
+
+@pytest.mark.asyncio
+async def test_refresh_token(monkeypatch, client):
+    async def override_session():
+        yield AsyncMock()
+    app.dependency_overrides[get_session] = override_session
+
+    async def fake_rotate(db, token):
+        return {"access_token": "a", "refresh_token": "r"}
+    monkeypatch.setattr(auth_tokens, "rotate_refresh_and_issue", fake_rotate)
+
+    resp = await client.post("/v1/auth/refresh", json={"refresh_token": "tok"})
+    assert resp.status_code == 200
+    assert resp.json() == {"access_token": "a", "refresh_token": "r"}
+    app.dependency_overrides.clear()
+
+@pytest.mark.asyncio
+async def test_logout_all_refresh(monkeypatch, client):
+    app.dependency_overrides[get_current_user_id] = lambda: "user"
+
+    async def fake_logout(uid):
+        return {"logout": True, "uid": uid}
+    monkeypatch.setattr(auth_tokens, "logout_all_refresh", fake_logout)
+
+    resp = await client.post("/v1/auth/logout")
+    assert resp.status_code == 200
+    assert resp.json() == {"logout": True, "uid": "user"}
+    app.dependency_overrides.clear()

--- a/tests/api/test_identities.py
+++ b/tests/api/test_identities.py
@@ -1,0 +1,55 @@
+import uuid
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from app.main import app
+from app.core.session import get_session
+from app.deps.auth import get_current_user_id
+from app.api.v1.endpoints import identities
+
+@pytest.mark.asyncio
+async def test_link_identity(monkeypatch, client):
+    db = SimpleNamespace()
+    async def override_session():
+        yield db
+    app.dependency_overrides[get_session] = override_session
+    app.dependency_overrides[get_current_user_id] = lambda: "user"
+
+    class DummySvc:
+        def __init__(self, db):
+            self.db = db
+        async def link_identity(self, user_id, provider, provider_sub, claims):
+            return SimpleNamespace(id=uuid.uuid4(), provider=provider.value, provider_sub=provider_sub)
+
+    monkeypatch.setattr(identities, "UserService", DummySvc)
+
+    resp = await client.post("/v1/identities/google", json={"provider_sub": "sub"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["provider"] == "google"
+    assert data["provider_sub"] == "sub"
+    app.dependency_overrides.clear()
+
+@pytest.mark.asyncio
+async def test_unlink_identity(monkeypatch, client):
+    commit = AsyncMock()
+    db = SimpleNamespace(commit=commit)
+    async def override_session():
+        yield db
+    app.dependency_overrides[get_session] = override_session
+    app.dependency_overrides[get_current_user_id] = lambda: "user"
+
+    class DummySvc:
+        def __init__(self, db):
+            self.ids = SimpleNamespace(delete_returning=AsyncMock(return_value=(1, [{"provider_sub": "sub"}])))
+
+    monkeypatch.setattr(identities, "UserService", DummySvc)
+
+    resp = await client.delete("/v1/identities/google")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["deleted"] is True
+    assert data["provider"] == "google"
+    assert data["provider_sub"] == "sub"
+    commit.assert_awaited()
+    app.dependency_overrides.clear()

--- a/tests/api/test_ping.py
+++ b/tests/api/test_ping.py
@@ -1,0 +1,7 @@
+import pytest
+
+@pytest.mark.asyncio
+async def test_ping_endpoint(client):
+    resp = await client.get("/v1/ping/")
+    assert resp.status_code == 200
+    assert resp.json() == {"message": "pong"}

--- a/tests/api/test_users.py
+++ b/tests/api/test_users.py
@@ -1,0 +1,53 @@
+import uuid
+import pytest
+from types import SimpleNamespace
+from datetime import datetime, timezone
+from app.main import app
+from app.core.session import get_session
+from app.deps.auth import get_current_user, get_current_user_id
+from app.api.v1.endpoints import users
+
+@pytest.mark.asyncio
+async def test_users_me(client):
+    user = SimpleNamespace(
+        id=uuid.uuid4(),
+        uid="u",
+        nickname="n",
+        created_at=datetime.now(timezone.utc),
+        updated_at=None,
+        last_login_at=None,
+    )
+    app.dependency_overrides[get_current_user] = lambda: user
+    resp = await client.get("/v1/users/me")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["uid"] == "u"
+    app.dependency_overrides.clear()
+
+@pytest.mark.asyncio
+async def test_set_nickname(monkeypatch, client):
+    db = SimpleNamespace()
+    async def override_session():
+        yield db
+    app.dependency_overrides[get_session] = override_session
+    app.dependency_overrides[get_current_user_id] = lambda: "user"
+
+    class DummySvc:
+        def __init__(self, db):
+            pass
+        async def update_nickname_once(self, user_id, nickname):
+            return SimpleNamespace(
+                id=uuid.uuid4(),
+                uid="u",
+                nickname=nickname,
+                created_at=datetime.now(timezone.utc),
+                updated_at=None,
+                last_login_at=None,
+            )
+
+    monkeypatch.setattr(users, "UserService", DummySvc)
+
+    resp = await client.patch("/v1/users/me/nickname", json={"nickname": "new"})
+    assert resp.status_code == 200
+    assert resp.json()["nickname"] == "new"
+    app.dependency_overrides.clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,8 +76,8 @@ async def async_session(test_db_url):
         yield session
     await engine.dispose()
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def client():
-    transport = ASGITransport(app=app, lifespan="on")
+    transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         yield ac

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,9 @@ import pytest_asyncio
 from app.core.config import settings
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
+from httpx import AsyncClient, ASGITransport
+from app.main import app
+
 
 def _urls():
     base = f"{settings.DB_USER}:{settings.DB_PASSWORD}@{settings.DB_HOST}:{settings.DB_PORT}"
@@ -72,3 +75,9 @@ async def async_session(test_db_url):
     async with session_factory() as session:
         yield session
     await engine.dispose()
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app, lifespan="on")
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac

--- a/tests/utils/test_refresh_tools.py
+++ b/tests/utils/test_refresh_tools.py
@@ -1,0 +1,35 @@
+import re
+from app.utils import refresh_tools as rt
+from app.core.config import settings
+
+
+def test_generate_and_hash_refresh():
+    plain1 = rt.generate_refresh_plain()
+    plain2 = rt.generate_refresh_plain()
+    assert plain1 != plain2
+    assert len(plain1) >= 86
+    h = rt.hash_refresh(plain1)
+    assert re.fullmatch(r"[0-9a-f]{64}", h)
+
+
+def test_redis_key_generation(monkeypatch):
+    monkeypatch.setattr(settings, "APP_ENV", "production")
+    token_hash = "abc123"
+    user_id = "user1"
+    tk = rt.redis_token_key(token_hash)
+    uk = rt.redis_user_set_key(user_id)
+    assert tk == f"prod:{settings.REFRESH_REDIS_PREFIX}{token_hash}"
+    assert uk == f"prod:{settings.REFRESH_USER_SET_PREFIX}{user_id}"
+
+
+def test_exp_ts():
+    now = rt.now_ts()
+    exp = rt.exp_ts()
+    diff = exp - now
+    assert settings.REFRESH_EXPIRES_SEC - 1 <= diff <= settings.REFRESH_EXPIRES_SEC + 1
+
+
+def test_json_roundtrip():
+    rec = rt.RefreshRecord(user_id="u1", iat=rt.now_ts(), exp=rt.exp_ts())
+    s = rt.to_json(rec)
+    assert rt.from_json(s) == rec


### PR DESCRIPTION
지금 access token이 한번 발급되고 나서 만료(1시간)시간 지나면 다시 로그인해야 하는 구조라
refresh token(30일) 발급해서 한번 로그인한기기에선 로그아웃하지 않는이상 재로그인이 바로되도록 하였습니다.
redis 사용하였습니다

* `app/utils/refresh_tools.py` 추가
  * Refresh Token 발급/해시/검증 유틸 구현
  * Redis 키 생성 시 `APP_ENV` prefix 적용 (`dev:rtk:*`, `dev:rtu:*`)
* `app/services/auth_service.py` 갱신
  * Google 로그인 시 access + refresh 동시 발급
  * `/v1/auth/refresh`: refresh 토큰 회전 (1회용 `GETDEL`)
  * `/v1/auth/logout`: 유저별 refresh 전부 폐기
* .env / Settings
  * APP_ENV (dev|stg|prod) 필수화
  * REFRESH_EXPIRES_SEC, REFRESH_HASH_PEPPER 설정 추가 **(env 파일 갱신 필요)**

---

### Access/Refresh 토큰 구조

* **Access Token**

  * HS256 JWT
  * **만료: 1시간 (3600초)**
  * 모든 API 요청에 `Authorization: Bearer <access>` 로 사용
  * 만료되면 더 이상 사용할 수 없음

* **Refresh Token**

  * Opaque 랜덤 토큰 (서버는 해시만 Redis에 저장)
  * **만료: 30일 (2592000초)**
  * `/v1/auth/refresh` 호출 시 1회용 회전(GETDEL)
    → 사용된 Refresh는 즉시 폐기되고 새 Refresh 발급
  * `/v1/auth/logout` 호출 시 해당 유저의 모든 Refresh 무효화

* **동작 요약**

  1. 로그인 시 Access(1h) + Refresh(30d) 동시 발급
  2. Access 만료 → 클라이언트가 Refresh 제출
     → 새 Access + 새 Refresh 발급 (회전)
  3. Refresh도 만료되면 → 로그인부터 다시 진행
  4. 로그아웃 시 서버/클라이언트 양쪽 토큰 즉시 폐기

---

### Redis 적용 사항

* **Infra**

  * `docker compose` 에 `redis` 컨테이너 추가 (`localhost:6379`)
  * `.env`에 `REDIS_URL` 설정
  * `APP_ENV=dev|stg|prod` 값 필수 → Redis key prefix로 사용

* **사용 방식**

  * **Refresh Token 저장소**로 Redis 활용
  * `SETEX` 으로 토큰 단위 키(`{env}:rtk:{hash}`) 저장 + TTL 관리 (30일)
  * `SADD` 로 유저별 토큰 해시 세트(`{env}:rtu:{user_id}`) 관리 → 로그아웃 시 일괄 폐기
  * `GETDEL` 로 Refresh 1회용 회전 지원 → 재사용/탈취 방지

* **컨벤션 문서**

  * Redis Key 네이밍 규칙은 위키에 별도 문서로 정리
  * [Redis-Key-Conventions](https://github.com/sangcheol-games/sangcheol-odyssey-hub/wiki/Redis-Key-Conventions)

---
close #9