### PR TITLE
[feature] (#11) add callback with session in google login

### DIFF
--- a/app/api/v1/endpoints/__init__.py
+++ b/app/api/v1/endpoints/__init__.py
@@ -1,7 +1,6 @@
 from fastapi import APIRouter
 from app.api.v1.endpoints import (
-    ping, auth_google, users, identities,
-    auth_tokens
+    ping, auth_google, users, identities, auth_tokens, auth_session, auth_google_callback
 )
 
 api_router = APIRouter()
@@ -10,3 +9,5 @@ api_router.include_router(auth_google.router)
 api_router.include_router(users.router)
 api_router.include_router(identities.router)
 api_router.include_router(auth_tokens.router)
+api_router.include_router(auth_session.router)
+api_router.include_router(auth_google_callback.router)

--- a/app/api/v1/endpoints/auth_google_callback.py
+++ b/app/api/v1/endpoints/auth_google_callback.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import HTMLResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+from redis.asyncio import Redis
+
+from app.core.session import get_session
+from app.core.config import settings
+from app.deps.redis import get_redis
+from app.utils.auth_session import (
+    set_result, set_error, get_status, get_code_verifier
+)
+from app.schemas.google_oauth import GoogleTokenRequest
+from app.services import auth_service as S
+
+router = APIRouter(prefix="/auth/google", tags=["auth"])
+
+@router.get("/callback", response_class=HTMLResponse)
+async def google_callback(
+    sid: str = Query(..., alias="state"),
+    code: str | None = Query(None),
+    error: str | None = Query(None),
+    r: Redis = Depends(get_redis),
+    db: AsyncSession = Depends(get_session),
+):
+    status_str, _, _ = await get_status(r, sid)
+    if status_str == "not_found":
+        raise HTTPException(status_code=404, detail="session not found")
+
+    if error:
+        await set_error(r, sid, f"google_error:{error}")
+        return "<!doctype html><title>Auth</title>Login failed"
+
+    if not code:
+        raise HTTPException(status_code=400, detail="missing code")
+
+    client_id = settings.GOOGLE_CLIENT_ID_WEB or (
+        settings.google_client_id_list[0] if settings.google_client_id_list else None
+    )
+    if not client_id or not settings.GOOGLE_REDIRECT_URI:
+        await set_error(r, sid, "SERVER_MISCONFIG")
+        raise HTTPException(status_code=500, detail="SERVER_MISCONFIG")
+
+    cv = await get_code_verifier(r, sid)
+    if not cv:
+        raise HTTPException(status_code=404, detail="session not found")
+
+    token_resp = await S.exchange_google_token(GoogleTokenRequest(
+        client_id=client_id,
+        client_secret=getattr(settings, "GOOGLE_CLIENT_SECRET", None),
+        code=code,
+        redirect_uri=settings.GOOGLE_REDIRECT_URI,
+        code_verifier=cv,
+    ))
+
+    if not token_resp.id_token:
+        await set_error(r, sid, "no_id_token")
+        return "<!doctype html><title>Auth</title>Login failed"
+
+    claims = await S.verify_google_id_token(token_resp.id_token)
+    tok = await S.handle_google_login(db, claims)
+    await set_result(r, sid, tok.model_dump())
+    return "<!doctype html><title>Auth</title>Login complete"

--- a/app/api/v1/endpoints/auth_session.py
+++ b/app/api/v1/endpoints/auth_session.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+from fastapi import APIRouter, HTTPException, Query, Response, status, Depends
+from pydantic import BaseModel
+from redis.asyncio import Redis
+from app.schemas.auth_io import AuthUrlResponse, TokenResponse
+from app.deps.redis import get_redis
+from app.utils.auth_session import create_auth_session, get_status
+
+router = APIRouter(prefix="/auth/session", tags=["auth"])
+
+class InitBody(BaseModel):
+    code_verifier: str
+
+@router.post("/init", response_model=AuthUrlResponse)
+async def init_auth_session(body: InitBody, r: Redis = Depends(get_redis)) -> AuthUrlResponse:
+    data = await create_auth_session(r, body.code_verifier)
+    return AuthUrlResponse(auth_url=data["auth_url"], session_id=data["session_id"])
+
+@router.get("/poll")
+async def poll_session(sid: str = Query(...), r: Redis = Depends(get_redis)):
+    status_str, result, error_msg = await get_status(r, sid)
+    if status_str == "not_found":
+        raise HTTPException(status_code=404, detail="session not found")
+    if status_str == "ready" and result:
+        return TokenResponse.model_validate(result)
+    if status_str == "error":
+        raise HTTPException(status_code=400, detail=error_msg or "auth failed")
+    return Response(content='{"message":"pending"}', media_type="application/json", status_code=status.HTTP_202_ACCEPTED)

--- a/app/deps/redis.py
+++ b/app/deps/redis.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+from redis.asyncio import Redis
+from app.utils.redis_client import get_redis as _get_redis
+
+def get_redis() -> Redis:
+    return _get_redis()

--- a/app/utils/auth_session.py
+++ b/app/utils/auth_session.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+import json, time, secrets, hashlib, base64
+from typing import Any
+from redis.asyncio import Redis
+
+SESSION_PREFIX = "authsess:"
+SESSION_TTL = 600
+
+def _key(sid: str) -> str:
+    return f"{SESSION_PREFIX}{sid}"
+
+def _now() -> int:
+    return int(time.time())
+
+def _sid() -> str:
+    raw = secrets.token_urlsafe(32)
+    h = hashlib.sha256(raw.encode()).digest()
+    return base64.urlsafe_b64encode(h)[:32].decode()
+
+def _nonce() -> str:
+    return secrets.token_urlsafe(16)
+
+async def create_auth_session(r: Redis, code_verifier: str) -> dict[str, str]:
+    sid = _sid()
+    nonce = _nonce()
+    rec = {
+        "status": "pending",
+        "code_verifier": code_verifier,
+        "nonce": nonce,
+        "created_at": _now(),
+        "result": None,
+        "error": None,
+    }
+    await r.setex(_key(sid), SESSION_TTL, json.dumps(rec))
+    auth_url = f"https://accounts.google.com/o/oauth2/v2/auth?response_type=code&scope=openid%20email%20profile&code_challenge_method=S256&state={sid}&nonce={nonce}"
+    return {"session_id": sid, "auth_url": auth_url}
+
+async def get_status(r: Redis, sid: str) -> tuple[str, Any | None, str | None]:
+    raw = await r.get(_key(sid))
+    if not raw:
+        return "not_found", None, None
+    rec = json.loads(raw)
+    st = rec.get("status")
+    if st == "ready":
+        return "ready", rec.get("result"), None
+    if st == "error":
+        return "error", None, rec.get("error")
+    return "pending", None, None
+
+async def get_code_verifier(r: Redis, sid: str) -> str | None:
+    raw = await r.get(_key(sid))
+    if not raw:
+        return None
+    return json.loads(raw).get("code_verifier")
+
+async def set_result(r: Redis, sid: str, result: Any) -> None:
+    raw = await r.get(_key(sid))
+    if not raw:
+        return
+    rec = json.loads(raw)
+    rec["status"] = "ready"
+    rec["result"] = result
+    await r.setex(_key(sid), SESSION_TTL, json.dumps(rec))
+
+async def set_error(r: Redis, sid: str, message: str) -> None:
+    raw = await r.get(_key(sid))
+    if not raw:
+        return
+    rec = json.loads(raw)
+    rec["status"] = "error"
+    rec["error"] = message
+    await r.setex(_key(sid), SESSION_TTL, json.dumps(rec))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "alembic>=1.16.4",
     "asyncpg>=0.30.0",
     "authlib>=1.6.2",
+    "fakeredis>=2.31.0",
     "fastapi>=0.116.1",
     "httpx>=0.28.1",
     "orjson>=3.11.2",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+asyncio_mode = strict
+asyncio_default_fixture_loop_scope = function
+testpaths = tests
+python_files = test_*.py
+filterwarnings =
+    ignore::DeprecationWarning

--- a/tests/api/test_auth_existing_paths.py
+++ b/tests/api/test_auth_existing_paths.py
@@ -1,0 +1,45 @@
+import pytest
+from types import SimpleNamespace
+from app.api.v1.endpoints import auth_google as E
+
+@pytest.mark.asyncio
+async def test_verify_id_token_endpoint(monkeypatch, client):
+    async def mock_verify(id_token):
+        return SimpleNamespace(sub="sub-1", email="u@test", email_verified=True)
+    async def mock_handle(db, claims):
+        return SimpleNamespace(access_token="a", refresh_token="r", expires_in=3600, is_new_user=True, token_type="bearer")
+    monkeypatch.setattr(E, "verify_google_id_token", mock_verify)
+    monkeypatch.setattr(E, "handle_google_login", mock_handle)
+
+    res = await client.post("/v1/auth/google/verify-id-token", json={"id_token":"X"})
+    assert res.status_code == 200
+    j = res.json()
+    assert j["access_token"] == "a"
+    assert j["refresh_token"] == "r"
+
+@pytest.mark.asyncio
+async def test_refresh_rotation_ok(monkeypatch, client, fake_redis):
+    from app.api.v1.endpoints import auth_tokens as T
+    async def fake_rotate(db, refresh_token):
+        return SimpleNamespace(access_token="rotated-acc", refresh_token="rotated-ref", expires_in=3600, token_type="bearer", is_new_user=False)
+    monkeypatch.setattr(T, "rotate_refresh_and_issue", fake_rotate)
+
+    res = await client.post("/v1/auth/refresh", json={"refresh_token":"dummy"})
+    assert res.status_code == 200
+    assert res.json()["access_token"] == "rotated-acc"
+
+@pytest.mark.asyncio
+async def test_logout_all_refresh_ok(monkeypatch, client):
+    from app.api.v1.endpoints import auth_tokens as T
+    async def fake_logout(user_id: str):
+        return {"message":"ok"}
+    monkeypatch.setattr(T, "logout_all_refresh", fake_logout)
+
+    import app.deps.auth as D
+    def fake_decode(token: str):
+        return {"sub":"user-1"}
+    monkeypatch.setattr(D, "_decode", fake_decode)
+
+    res = await client.post("/v1/auth/logout", headers={"Authorization":"Bearer faketoken"})
+    assert res.status_code == 200
+    assert res.json() == {"message":"ok"}

--- a/tests/api/test_auth_google_callback.py
+++ b/tests/api/test_auth_google_callback.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import HTMLResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+from redis.asyncio import Redis
+from pydantic import BaseModel
+
+from app.core.session import get_session
+from app.core.config import settings
+from app.utils.redis_client import get_redis
+from app.utils.auth_session import (
+    set_result, set_error, get_status, get_code_verifier
+)
+from app.schemas.google_oauth import GoogleTokenRequest
+from app.schemas.auth_io import TokenResponse
+from app.services import auth_service as S
+
+router = APIRouter(prefix="/auth/google", tags=["auth"])
+
+@router.get("/callback", response_class=HTMLResponse)
+async def google_callback(
+    sid: str = Query(..., alias="state"),
+    code: str | None = Query(None),
+    error: str | None = Query(None),
+    r: Redis = Depends(get_redis),
+    db: AsyncSession = Depends(get_session),
+):
+    status_str, _, _ = await get_status(r, sid)
+    if status_str == "not_found":
+        raise HTTPException(status_code=404, detail="session not found")
+
+    if error:
+        await set_error(r, sid, f"google_error:{error}")
+        return "<!doctype html><title>Auth</title>Login failed"
+
+    if not code:
+        raise HTTPException(status_code=400, detail="missing code")
+
+    client_id = settings.GOOGLE_CLIENT_ID_WEB or (
+        settings.google_client_id_list[0] if settings.google_client_id_list else None
+    )
+    if not client_id or not settings.GOOGLE_REDIRECT_URI:
+        await set_error(r, sid, "SERVER_MISCONFIG")
+        raise HTTPException(status_code=500, detail="SERVER_MISCONFIG")
+
+    cv = await get_code_verifier(r, sid)
+    if not cv:
+        raise HTTPException(status_code=404, detail="session not found")
+
+    token_resp = await S.exchange_google_token(GoogleTokenRequest(
+        client_id=client_id,
+        client_secret=getattr(settings, "GOOGLE_CLIENT_SECRET", None),
+        code=code,
+        redirect_uri=settings.GOOGLE_REDIRECT_URI,
+        code_verifier=cv,
+    ))
+
+    if not token_resp.id_token:
+        await set_error(r, sid, "no_id_token")
+        return "<!doctype html><title>Auth</title>Login failed"
+
+    claims = await S.verify_google_id_token(token_resp.id_token)
+    tok = await S.handle_google_login(db, claims)
+
+    if isinstance(tok, BaseModel):
+        payload = tok.model_dump()
+    elif isinstance(tok, dict):
+        payload = tok
+    else:
+        payload = TokenResponse.model_validate(tok).model_dump()
+
+    await set_result(r, sid, payload)
+    return "<!doctype html><title>Auth</title>Login complete"

--- a/tests/api/test_auth_session.py
+++ b/tests/api/test_auth_session.py
@@ -1,0 +1,48 @@
+import json
+import pytest
+from app.utils import auth_session as a_sess
+
+@pytest.mark.asyncio
+async def test_session_init_returns_auth_url_and_sid(client, fake_redis):
+    res = await client.post("/v1/auth/session/init", json={"code_verifier": "abc.verifier-123"})
+    assert res.status_code == 200
+    data = res.json()
+    assert "auth_url" in data and "session_id" in data
+    sid = data["session_id"]
+    status, result, err = await a_sess.get_status(fake_redis, sid)
+    assert status == "pending"
+    cv = await a_sess.get_code_verifier(fake_redis, sid)
+    assert cv == "abc.verifier-123"
+
+@pytest.mark.asyncio
+async def test_session_poll_pending(client, fake_redis):
+    rec = {"status":"pending","code_verifier":"v","nonce":"n","created_at":0,"result":None,"error":None}
+    sid = "S123"
+    await fake_redis.setex(a_sess._key(sid), 600, json.dumps(rec))
+    res = await client.get("/v1/auth/session/poll", params={"sid": sid})
+    assert res.status_code == 202
+    assert res.json() == {"message":"pending"}
+
+@pytest.mark.asyncio
+async def test_session_poll_ready(client, fake_redis):
+    sid = "READY1"
+    token = {"access_token":"acc","refresh_token":"ref","expires_in":3600,"token_type":"bearer","is_new_user":False}
+    rec = {"status":"ready","code_verifier":"v","nonce":"n","created_at":0,"result":token,"error":None}
+    await fake_redis.setex(a_sess._key(sid), 600, json.dumps(rec))
+    res = await client.get("/v1/auth/session/poll", params={"sid": sid})
+    assert res.status_code == 200
+    assert res.json()["access_token"] == "acc"
+
+@pytest.mark.asyncio
+async def test_session_poll_error(client, fake_redis):
+    sid = "ERR1"
+    rec = {"status":"error","code_verifier":"v","nonce":"n","created_at":0,"result":None,"error":"google_error:access_denied"}
+    await fake_redis.setex(a_sess._key(sid), 600, json.dumps(rec))
+    res = await client.get("/v1/auth/session/poll", params={"sid": sid})
+    assert res.status_code == 400
+    assert "google_error" in res.json()["detail"]
+
+@pytest.mark.asyncio
+async def test_session_poll_not_found(client):
+    res = await client.get("/v1/auth/session/poll", params={"sid": "NOPE"})
+    assert res.status_code == 404

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,83 +1,81 @@
-import psycopg
+import asyncio
+import json
+import os
 import pytest
-from alembic.config import Config
-from alembic import command
 import pytest_asyncio
-from app.core.config import settings
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.orm import sessionmaker
-from httpx import AsyncClient, ASGITransport
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
+import sqlalchemy as sa
+from fakeredis import aioredis as _fakeredis
+
 from app.main import app
+from app.core import config as cfg
+from app.utils.redis_client import get_redis as _get_redis
 
+@pytest.fixture(scope="session")
+def event_loop():
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
 
-def _urls():
-    base = f"{settings.DB_USER}:{settings.DB_PASSWORD}@{settings.DB_HOST}:{settings.DB_PORT}"
-    name = settings.DB_NAME + "_test"
-    return (
-        name,
-        f"postgresql+psycopg://{base}/{name}",
-        f"postgresql+asyncpg://{base}/{name}",
-        f"postgresql://{base}/postgres",
-    )
-
-def _create_db(db_name, admin_url):
-    with psycopg.connect(admin_url, autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute("SELECT 1 FROM pg_database WHERE datname=%s", (db_name,))
-            if cur.fetchone() is None:
-                cur.execute(f'DROP DATABASE IF EXISTS "{db_name}"')
-                cur.execute(f'CREATE DATABASE "{db_name}"')
-
-def _drop_db(db_name, admin_url):
-    with psycopg.connect(admin_url, autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute(
-                """
-                SELECT pid
-                FROM pg_stat_activity
-                WHERE datname = %s AND pid <> pg_backend_pid()
-                """,
-                (db_name,),
-            )
-            for (pid,) in cur.fetchall():
-                cur.execute("SELECT pg_terminate_backend(%s)", (pid,))
-            cur.execute(f'DROP DATABASE IF EXISTS "{db_name}"')
-
-@pytest.fixture(scope="session", autouse=True)
-def _setup_db():
-    db_name, sync_url, async_url, admin_url = _urls()
-    _create_db(db_name, admin_url)
-    cfg = Config("alembic.ini")
-    cfg.set_main_option("sqlalchemy.url", sync_url)
-    command.upgrade(cfg, "head")
-    yield
-    _drop_db(db_name, admin_url)
-
-
-@pytest.fixture()
-def test_db_url():
-    _, _, async_url, _ = _urls()
-    return async_url
+@pytest.fixture(autouse=True)
+def _patch_settings(monkeypatch):
+    monkeypatch.setenv("APP_ENV", "test")
+    monkeypatch.setenv("JWT_SECRET", "test-secret")
+    monkeypatch.setenv("JWT_EXPIRES_SEC", "3600")
+    monkeypatch.setenv("REFRESH_EXPIRES_SEC", "2592000")
+    monkeypatch.setenv("REFRESH_HASH_PEPPER", "pepper")
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.setenv("GOOGLE_CLIENT_ID_WEB", "cid")
+    monkeypatch.setenv("GOOGLE_REDIRECT_URI", "http://localhost:8000/v1/auth/google/callback")
+    monkeypatch.setenv("GOOGLE_CLIENT_IDS", "cid")
+    from app.core import config as _cfg
+    _cfg.settings = _cfg.Settings()
 
 @pytest_asyncio.fixture
-async def async_engine():
-    _, _, async_url, _ = _urls()
-    engine = create_async_engine(async_url, future=True)
+async def fake_redis():
+    r = _fakeredis.FakeRedis(decode_responses=True)
     try:
-        yield engine
+        await r.flushall()
+        yield r
     finally:
-        await engine.dispose()
+        try:
+            await r.aclose()
+        except Exception:
+            pass
+
+@pytest.fixture(autouse=True)
+def _override_redis(fake_redis, monkeypatch):
+    import app.utils.redis_client as rc
+    app.dependency_overrides[rc.get_redis] = lambda: fake_redis
+    rc._redis = fake_redis
+    import app.services.auth_service as auth_service
+    monkeypatch.setattr(auth_service, "redis_from_url", lambda *a, **k: fake_redis)
 
 @pytest_asyncio.fixture
-async def async_session(test_db_url):
-    engine = create_async_engine(test_db_url)
-    session_factory = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
-    async with session_factory() as session:
-        yield session
-    await engine.dispose()
-
-@pytest_asyncio.fixture
-async def client():
+async def client(_override_redis, event_loop):
     transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        yield ac
+    async with AsyncClient(transport=transport, base_url="http://testserver") as c:
+        yield c
+
+@pytest.fixture(scope="session")
+def test_db_url():
+    return cfg.settings.db_url_async
+
+@pytest_asyncio.fixture
+async def async_session():
+    engine = create_async_engine(
+        cfg.settings.db_url_async,
+        pool_pre_ping=True,
+        pool_recycle=1800,
+        json_serializer=lambda o: json.dumps(o),
+    )
+    async with engine.begin() as conn:
+        await conn.execute(sa.text('TRUNCATE TABLE "identity","user" RESTART IDENTITY CASCADE'))
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    async with SessionLocal() as session:
+        try:
+            yield session
+        finally:
+            await session.rollback()
+    await engine.dispose()

--- a/tests/models/test_user_model.py
+++ b/tests/models/test_user_model.py
@@ -4,10 +4,9 @@ import app.db.base_class  # noqa: F401
 from app.models.user import User
 from app.models.identity import Identity, Provider
 
-
 @pytest.mark.asyncio
 async def test_user_model_relationship(async_session):
-    user = User(uid="user1", nickname="nick")
+    user = User(uid=f"user-{uuid.uuid4()}", nickname="nick")
     async_session.add(user)
     await async_session.flush()
     assert isinstance(user.id, uuid.UUID)
@@ -19,4 +18,3 @@ async def test_user_model_relationship(async_session):
     await async_session.flush()
     await async_session.refresh(user)
     assert len(user.identities) == 1
-    

--- a/tests/repositories/test_user_repo.py
+++ b/tests/repositories/test_user_repo.py
@@ -1,25 +1,27 @@
+import uuid
 import pytest
 import app.db.base_class  # noqa: F401
 from app.models.user import User
 from app.repositories.user_repo import UserRepository
 
-
 @pytest.mark.asyncio
 async def test_user_repository_crud(async_session):
     repo = UserRepository(async_session)
-    user = User(uid="user1", nickname="nick")
+    uid1 = f"user-{uuid.uuid4()}"
+    uid2 = f"user-{uuid.uuid4()}"
+    user = User(uid=uid1, nickname="nick")
     await repo.add(user)
     await async_session.commit()
 
     fetched = await repo.get(user.id)
-    assert fetched.uid == "user1"
+    assert fetched.uid == uid1
 
-    fetched_uid = await repo.get_by_uid("user1")
+    fetched_uid = await repo.get_by_uid(uid1)
     assert fetched_uid.id == user.id
 
-    user2 = User(uid="user2", nickname="nick")
+    user2 = User(uid=uid2, nickname="nick")
     await repo.add(user2)
     await async_session.commit()
 
     users = await repo.get_all_by_nickname("nick")
-    assert {u.uid for u in users} == {"user1", "user2"}
+    assert {u.uid for u in users} == {uid1, uid2}

--- a/tests/utils/test_auth_session_utils.py
+++ b/tests/utils/test_auth_session_utils.py
@@ -1,0 +1,23 @@
+import json
+import pytest
+from fakeredis.aioredis import FakeRedis
+from app.utils import auth_session as a_sess
+
+@pytest.mark.asyncio
+async def test_create_auth_session_and_status(monkeypatch):
+    r = FakeRedis(decode_responses=True)
+    data = await a_sess.create_auth_session(r, "verifier-xyz")
+    assert "session_id" in data and "auth_url" in data
+    sid = data["session_id"]
+
+    status, result, err = await a_sess.get_status(r, sid)
+    assert status == "pending" and result is None and err is None
+    assert await a_sess.get_code_verifier(r, sid) == "verifier-xyz"
+
+    await a_sess.set_result(r, sid, {"ok": True})
+    status, result, err = await a_sess.get_status(r, sid)
+    assert status == "ready" and result == {"ok": True} and err is None
+
+    await a_sess.set_error(r, sid, "oops")
+    status, result, err = await a_sess.get_status(r, sid)
+    assert status == "error" and result is None and err == "oops"

--- a/uv.lock
+++ b/uv.lock
@@ -174,6 +174,19 @@ wheels = [
 ]
 
 [[package]]
+name = "fakeredis"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "redis" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/10/c829c3475a26005ebf177057fdf54e2a29025ffc2232d02fb1ae8ac1de68/fakeredis-2.31.0.tar.gz", hash = "sha256:2942a7e7900fd9076ff9e608b9190a87315ac5a325a9ab8bfe288a2d985ecd23", size = 170163, upload-time = "2025-08-11T14:58:20.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/ef/25639beb5d93188b4b6502f601d8f97db77e362774f0183a48e995353c58/fakeredis-2.31.0-py3-none-any.whl", hash = "sha256:2584e57d93df4eb8e87931b29279902826d3caf77d06911106df4e066c2ad198", size = 117666, upload-time = "2025-08-11T14:58:19.03Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.116.1"
 source = { registry = "https://pypi.org/simple" }
@@ -729,6 +742,7 @@ dependencies = [
     { name = "alembic" },
     { name = "asyncpg" },
     { name = "authlib" },
+    { name = "fakeredis" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "orjson" },
@@ -755,6 +769,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.16.4" },
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "authlib", specifier = ">=1.6.2" },
+    { name = "fakeredis", specifier = ">=2.31.0" },
     { name = "fastapi", specifier = ">=0.116.1" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "orjson", specifier = ">=3.11.2" },
@@ -783,6 +798,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<img width="607" height="751" alt="image" src="https://github.com/user-attachments/assets/91c13aa7-ffbc-4c1b-8345-c1bea4e6a789" />


* Google 로그인 플로우에서, session 기반 callback 방식을 도입
  * Unity 클라이언트가 Google OAuth 인증 페이지를 열기 전에 먼저 서버에 세션 생성 요청
    * 서버가 session_id 발급 및 Redis에 상태 저장
  * Unity 클라이언트는 session_id를 가지고 OAuth 인증 페이지를 오픈 (state에 session_id 포함)
  * 사용자가 로그인 완료하면 Google이 서버의 redirect_uri로 code 전달
    * 서버가 해당 세션 ID를 기준으로 Redis에 토큰 교환 결과 저장
* 클라이언트는 session_id를 이용한 polling으로 로그인 결과(access/refresh 토큰)를 안전하게 수신

### 테스트
* pytest 통과
* 유니티와 통합 테스트 통과, 유니티 레포의 `test/test-api` branch에서 통합테스트 가능


close #11 