### PR TITLE
[feature] (#14) add steam auth login service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,6 @@ GOOGLE_CLIENT_IDS=your-google-client-id1,your-google-client-id2,...
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 GOOGLE_REDIRECT_URI=http://localhost:3000/auth/callback/google
 GOOGLE_CLIENT_ID_WEB=your-google-client-id-web
+
+STEAM_WEB_API_KEY=your-steam-web-api-key
+STEAM_APP_ID=your-steam-app-id

--- a/.env.example
+++ b/.env.example
@@ -1,25 +1,25 @@
+# App Config
 APP_ENV=dev
 APP_HOST=0.0.0.0
 APP_PORT=8000
 
+# Database
 DB_HOST=localhost
 DB_PORT=55432
 DB_USER=postgres
 DB_PASSWORD=postgres
 DB_NAME=sangcheol
 
+# Redis
 REDIS_URL=redis://localhost:6379/0
 
-JWT_SECRET=use-a-long-random-string
-JWT_EXPIRES_SEC=3600
-
-REFRESH_EXPIRES_SEC=2592000
-REFRESH_HASH_PEPPER=use-a-long-random-string
-
+# Auth
+JWT_SECRET=your-super-secret-key-change-me
 GOOGLE_CLIENT_IDS=your-google-client-id1,your-google-client-id2,...
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 GOOGLE_REDIRECT_URI=http://localhost:3000/auth/callback/google
 GOOGLE_CLIENT_ID_WEB=your-google-client-id-web
 
+# Steam Auth
 STEAM_WEB_API_KEY=your-steam-web-api-key
 STEAM_APP_ID=your-steam-app-id

--- a/.gitignore
+++ b/.gitignore
@@ -201,3 +201,5 @@ pyrightconfig.json
 .tools/
 .dev/
 # End of https://www.toptal.com/developers/gitignore/api/python,redis,visualstudiocode
+
+GEMINI.md

--- a/app/api/v1/endpoints/__init__.py
+++ b/app/api/v1/endpoints/__init__.py
@@ -1,11 +1,12 @@
 from fastapi import APIRouter
 from app.api.v1.endpoints import (
-    ping, auth_google, users, identities, auth_tokens, auth_session, auth_google_callback
+    ping, auth_google, auth_steam, users, identities, auth_tokens, auth_session, auth_google_callback
 )
 
 api_router = APIRouter()
 api_router.include_router(ping.router)
 api_router.include_router(auth_google.router)
+api_router.include_router(auth_steam.router)
 api_router.include_router(users.router)
 api_router.include_router(identities.router)
 api_router.include_router(auth_tokens.router)

--- a/app/api/v1/endpoints/auth_steam.py
+++ b/app/api/v1/endpoints/auth_steam.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.session import get_session
+from app.schemas.auth_io import TokenResponse
+from app.schemas.steam_auth import SteamLoginRequest
+from app.services.auth_steam import handle_steam_login
+
+router = APIRouter(prefix="/auth/steam", tags=["auth"])
+
+@router.post("/login", response_model=TokenResponse)
+async def steam_login(
+    body: SteamLoginRequest,
+    db: AsyncSession = Depends(get_session),
+) -> TokenResponse:
+    return await handle_steam_login(db, body.ticket)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,7 +1,19 @@
+import os
+from pathlib import Path
+import logging
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+# 프로젝트 루트 디렉토리 설정 (app/core/config.py 기준 세 단계 위)
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
+ENV_FILE = BASE_DIR / ".env"
+
 class Settings(BaseSettings):
-    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+    # env_file을 절대 경로로 지정하여 실행 위치와 상관없이 .env를 로드하도록 함
+    model_config = SettingsConfigDict(
+        env_file=ENV_FILE, 
+        extra="ignore",
+        env_file_encoding='utf-8'
+    )
 
     APP_ENV: str = "dev"
     APP_HOST: str = "0.0.0.0"
@@ -25,12 +37,12 @@ class Settings(BaseSettings):
     REFRESH_HASH_PEPPER: str | None = None
 
     GOOGLE_CLIENT_IDS: str = ""
-    GOOGLE_CLIENT_SECRET: str | None = None # 웹 클라에만 필요
-    GOOGLE_REDIRECT_URI: str | None = None # 웹 클라에만 필요
-    GOOGLE_CLIENT_ID_WEB: str | None = None # 웹 클라에만 필요
+    GOOGLE_CLIENT_SECRET: str | None = None
+    GOOGLE_REDIRECT_URI: str | None = None
+    GOOGLE_CLIENT_ID_WEB: str | None = None
 
-    STEAM_WEB_API_KEY: str | None = None
-    STEAM_APP_ID: str | None = "4566350"
+    STEAM_WEB_API_KEY: str = ""
+    STEAM_APP_ID: str = "4566350"
 
     @property
     def db_url_async(self) -> str:
@@ -52,3 +64,16 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
+
+logger = logging.getLogger(__name__)
+
+logger.info(f"Looking for .env at: {ENV_FILE}")
+if ENV_FILE.exists():
+    logger.info(".env file found.")
+else:
+    logger.warning(f".env file NOT found at {ENV_FILE}")
+
+if settings.STEAM_WEB_API_KEY:
+    logger.info("Steam Web API Key is configured.")
+else:
+    logger.error("STEAM_WEB_API_KEY is EMPTY in Settings!")

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -29,6 +29,9 @@ class Settings(BaseSettings):
     GOOGLE_REDIRECT_URI: str | None = None # 웹 클라에만 필요
     GOOGLE_CLIENT_ID_WEB: str | None = None # 웹 클라에만 필요
 
+    STEAM_WEB_API_KEY: str | None = None
+    STEAM_APP_ID: str | None = "4566350"
+
     @property
     def db_url_async(self) -> str:
         return (

--- a/app/schemas/steam_auth.py
+++ b/app/schemas/steam_auth.py
@@ -1,0 +1,4 @@
+from pydantic import BaseModel
+
+class SteamLoginRequest(BaseModel):
+    ticket: str

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -66,17 +66,7 @@ async def verify_google_id_token(id_token: str) -> GoogleIdClaims:
 
     return GoogleIdClaims.model_validate(claims)
 
-async def handle_google_login(db: AsyncSession, claims: GoogleIdClaims) -> TokenResponse:
-    if not claims.sub:
-        raise HTTPException(status_code=400, detail="id_token missing sub")
-    svc = UserService(db)
-    user, is_new_user = await svc.create_or_get_social_user(
-        provider=Provider.google,
-        provider_sub=claims.sub,
-        claims=claims.model_dump(exclude_none=True),
-    )
-    user_id = str(user.id)
-
+async def issue_auth_tokens(user_id: str, is_new_user: bool) -> TokenResponse:
     access_token = issue_access_token(user_id)
 
     plain = generate_refresh_plain()
@@ -93,6 +83,17 @@ async def handle_google_login(db: AsyncSession, claims: GoogleIdClaims) -> Token
         expires_in=int(settings.JWT_EXPIRES_SEC),
         is_new_user=is_new_user,
     )
+
+async def handle_google_login(db: AsyncSession, claims: GoogleIdClaims) -> TokenResponse:
+    if not claims.sub:
+        raise HTTPException(status_code=400, detail="id_token missing sub")
+    svc = UserService(db)
+    user, is_new_user = await svc.create_or_get_social_user(
+        provider=Provider.google,
+        provider_sub=claims.sub,
+        claims=claims.model_dump(exclude_none=True),
+    )
+    return await issue_auth_tokens(str(user.id), is_new_user)
 
 async def rotate_refresh_and_issue(db: AsyncSession, refresh_plain: str) -> TokenResponse:
     if not refresh_plain:

--- a/app/services/auth_steam.py
+++ b/app/services/auth_steam.py
@@ -1,0 +1,45 @@
+import httpx
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.identity import Provider
+from app.services.user_service import UserService
+from app.services.auth_service import issue_auth_tokens
+from app.schemas.auth_io import TokenResponse
+
+STEAM_AUTHENTICATE_URL = "https://api.steampowered.com/ISteamUserAuth/AuthenticateUserTicket/v1/"
+
+async def handle_steam_login(db: AsyncSession, ticket: str) -> TokenResponse:
+    if not settings.STEAM_WEB_API_KEY or not settings.STEAM_APP_ID:
+        raise HTTPException(status_code=500, detail="SERVER_MISCONFIG: Steam credentials missing")
+
+    async with httpx.AsyncClient(timeout=10) as client:
+        r = await client.get(
+            STEAM_AUTHENTICATE_URL,
+            params={
+                "key": settings.STEAM_WEB_API_KEY,
+                "appid": settings.STEAM_APP_ID,
+                "ticket": ticket,
+            }
+        )
+
+    if r.status_code != 200:
+        raise HTTPException(status_code=400, detail="Steam authentication request failed")
+
+    data = r.json()
+    params = data.get("response", {}).get("params", {})
+    if "steamid" not in params:
+        error_desc = data.get("response", {}).get("error", {}).get("errordesc", "Unknown error")
+        raise HTTPException(status_code=400, detail=f"Invalid steam ticket: {error_desc}")
+
+    steamid = params["steamid"]
+
+    svc = UserService(db)
+    user, is_new_user = await svc.create_or_get_social_user(
+        provider=Provider.steam,
+        provider_sub=steamid,
+        claims={"steamid": steamid}
+    )
+
+    return await issue_auth_tokens(str(user.id), is_new_user)

--- a/app/services/auth_steam.py
+++ b/app/services/auth_steam.py
@@ -11,26 +11,32 @@ from app.schemas.auth_io import TokenResponse
 STEAM_AUTHENTICATE_URL = "https://api.steampowered.com/ISteamUserAuth/AuthenticateUserTicket/v1/"
 
 async def handle_steam_login(db: AsyncSession, ticket: str) -> TokenResponse:
-    if not settings.STEAM_WEB_API_KEY or not settings.STEAM_APP_ID:
-        raise HTTPException(status_code=500, detail="SERVER_MISCONFIG: Steam credentials missing")
+    if not settings.STEAM_WEB_API_KEY:
+        raise HTTPException(
+            status_code=500, 
+            detail="SERVER_MISCONFIG: STEAM_WEB_API_KEY is missing. Please check your .env file."
+        )
+    
+    steam_app_id = settings.STEAM_APP_ID or "4566350"
 
     async with httpx.AsyncClient(timeout=10) as client:
         r = await client.get(
             STEAM_AUTHENTICATE_URL,
             params={
                 "key": settings.STEAM_WEB_API_KEY,
-                "appid": settings.STEAM_APP_ID,
+                "appid": steam_app_id,
                 "ticket": ticket,
             }
         )
 
     if r.status_code != 200:
-        raise HTTPException(status_code=400, detail="Steam authentication request failed")
+        raise HTTPException(status_code=400, detail=f"Steam authentication request failed: {r.status_code}")
 
     data = r.json()
     params = data.get("response", {}).get("params", {})
     if "steamid" not in params:
-        error_desc = data.get("response", {}).get("error", {}).get("errordesc", "Unknown error")
+        error_info = data.get("response", {}).get("error", {})
+        error_desc = error_info.get("errordesc", "Unknown error")
         raise HTTPException(status_code=400, detail=f"Invalid steam ticket: {error_desc}")
 
     steamid = params["steamid"]

--- a/tests/api/test_auth_steam.py
+++ b/tests/api/test_auth_steam.py
@@ -1,0 +1,56 @@
+import pytest
+from unittest.mock import patch
+from httpx import Response
+
+@pytest.mark.asyncio
+async def test_steam_login_success(client, async_session):
+    # 1. Steam API 응답 모킹 (성공 케이스)
+    mock_response = {
+        "response": {
+            "params": {
+                "result": "OK",
+                "steamid": "76561198000000001",
+                "ownersteamid": "76561198000000001",
+                "vacbanned": False,
+                "publisherbanned": False
+            }
+        }
+    }
+
+    with patch("httpx.AsyncClient.get") as mock_get:
+        mock_get.return_value = Response(200, json=mock_response)
+
+        # 2. 우리 서버의 스팀 로그인 엔드포인트 호출
+        response = await client.post(
+            "/v1/auth/steam/login",
+            json={"ticket": "mock_valid_ticket_hex_string"}
+        )
+
+        # 3. 결과 검증
+        assert response.status_code == 200
+        data = response.json()
+        assert "access_token" in data
+        assert "refresh_token" in data
+        assert data["is_new_user"] is True  # 첫 로그인이므로 True
+
+@pytest.mark.asyncio
+async def test_steam_login_invalid_ticket(client):
+    # 1. Steam API 응답 모킹 (실패 케이스)
+    mock_response = {
+        "response": {
+            "error": {
+                "errordesc": "Invalid ticket"
+            }
+        }
+    }
+
+    with patch("httpx.AsyncClient.get") as mock_get:
+        mock_get.return_value = Response(200, json=mock_response)
+
+        response = await client.post(
+            "/v1/auth/steam/login",
+            json={"ticket": "invalid_ticket"}
+        )
+
+        assert response.status_code == 400
+        assert "Invalid steam ticket" in response.json()["detail"]


### PR DESCRIPTION

<img width="1121" height="381" alt="image" src="https://github.com/user-attachments/assets/3e6d3f1c-fd52-483d-b523-311cb671e58c" />
<img width="1103" height="392" alt="image" src="https://github.com/user-attachments/assets/dba3d788-093c-4852-bca8-a64565d927e1" />

Steam 로그인을 구현하였습니다.
실제 환경에서 테스트 해보려면 클라이언트에서 ticket을 발급해서 `/api/v1/auth/steam/login`으로 post 요청을 보내면 되는데
지금 클라이언트와 연동 테스트 진행 단계가 아니라서 임의의 문자열로 실제 Steam Web API 호출해 invalid ticket 에러 메세지 받는 테스트를 해보았습니다.

pytest로 mock response를 이용한 테스트도 성공했습니다.

이후 연동 테스트에서 문제 상황 발생해면 추가로 수정하겠습니다.

close #14 